### PR TITLE
Docs: Add information about changing display mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -22,6 +22,8 @@ You'll probably want to add =org-sticky-header-mode= to your =org-mode-hook= too
 
 If =org-startup-indented= is enabled, the =org-sticky-header-prefix= will be automatically set to match the =org-indent-mode= prefixes; otherwise you may wish to customize it.
 
+To customize the display between the three available modes, the variable =org-sticky-header-full-path= can be set with =full=, =reversed= or =nil=.
+
 * Changelog
 
 ** 1.0.1


### PR DESCRIPTION
This change is to provide detail about the variable to be changed in order to customize the display mode. It also fixes [this issue](https://github.com/alphapapa/org-sticky-header/issues/16).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alphapapa/org-sticky-header/17)
<!-- Reviewable:end -->
