### PR TITLE
Fix "Error during redisplay" when point is before first Org heading

### DIFF
--- a/org-sticky-header.el
+++ b/org-sticky-header.el
@@ -134,38 +134,40 @@ is enabled."
   "Return string of Org heading or outline path for display in header line."
   (org-with-wide-buffer
    (goto-char (window-start))
-   (unless (org-before-first-heading-p)
-     ;; No non-header lines above top displayed header
-     (when (or org-sticky-header-always-show-header
-               (not (org-at-heading-p)))
-       ;; Header should be shown
-       (when (fboundp 'org-inlinetask-in-task-p)
-         ;; Skip inline tasks
-         (while (and (org-back-to-heading)
-                     (org-inlinetask-in-task-p))
-           (forward-line -1)))
-       (cond
-        ;; FIXME: Convert cond back to pcase, but one compatible with Emacs 24
-        ((null org-sticky-header-full-path)
-         (concat (org-sticky-header--get-prefix)
-                 (org-get-heading t t)))
-        ((eq org-sticky-header-full-path 'full)
-         (concat (org-sticky-header--get-prefix)
-                 (org-format-outline-path (org-get-outline-path t)
-                                          (window-width)
-                                          nil org-sticky-header-outline-path-separator)))
-        ((eq org-sticky-header-full-path 'reversed)
-         (let ((s (concat (org-sticky-header--get-prefix)
-                          (mapconcat 'identity
-                                     (nreverse (org-split-string (org-format-outline-path (org-get-outline-path t)
-                                                                                          1000 nil "")
-                                                                 ""))
-                                     org-sticky-header-outline-path-reversed-separator))))
-           (if (> (length s) (window-width))
-               (concat (substring s 0 (- (window-width) 2))
-                       "..")
-             s)))
-        (t nil))))))
+   (if (org-before-first-heading-p)
+       ""
+     (progn
+       ;; No non-header lines above top displayed header
+       (when (or org-sticky-header-always-show-header
+                 (not (org-at-heading-p)))
+         ;; Header should be shown
+         (when (fboundp 'org-inlinetask-in-task-p)
+           ;; Skip inline tasks
+           (while (and (org-back-to-heading)
+                       (org-inlinetask-in-task-p))
+             (forward-line -1)))
+         (cond
+          ;; FIXME: Convert cond back to pcase, but one compatible with Emacs 24
+          ((null org-sticky-header-full-path)
+           (concat (org-sticky-header--get-prefix)
+                   (org-get-heading t t)))
+          ((eq org-sticky-header-full-path 'full)
+           (concat (org-sticky-header--get-prefix)
+                   (org-format-outline-path (org-get-outline-path t)
+                                            (window-width)
+                                            nil org-sticky-header-outline-path-separator)))
+          ((eq org-sticky-header-full-path 'reversed)
+           (let ((s (concat (org-sticky-header--get-prefix)
+                            (mapconcat 'identity
+                                       (nreverse (org-split-string (org-format-outline-path (org-get-outline-path t)
+                                                                                            1000 nil "")
+                                                                   ""))
+                                       org-sticky-header-outline-path-reversed-separator))))
+             (if (> (length s) (window-width))
+                 (concat (substring s 0 (- (window-width) 2))
+                         "..")
+               s)))
+          (t "")))))))
 
 (defun org-sticky-header--get-prefix ()
   "Return prefix string depending on value of `org-sticky-header-prefix'."


### PR DESCRIPTION
This error also showed up in a blank Org buffer.

> Error during redisplay: (eval (progn (setq org-sticky-header-stickyline (propertize (org-sticky-header--fetch-stickyline) 'keymap org-sticky-header-keymap)) (list (propertize " " 'display '((space :align-to 0))) 'org-sticky-header-stickyline))) signaled (wrong-type-argument stringp nil)

I do not know if I am seeing this behavior as I am using the latest master builds of emacs and Org mode. But the error made sense.. `org-sticky-header--fetch-stickyline` was returning nil when the point was in a blank Org buffer or before the first Org heading.

My \*Messages\* buffer will fill up with these:

![image](https://user-images.githubusercontent.com/3578197/92133718-b396a500-edd6-11ea-9d76-2b00026023b1.png)


This PR fixes that, and also ensures that the function always returns a string.. returns `""` instead of `nil`.